### PR TITLE
Add ExceptionHandleMiddleware for centralized error handling

### DIFF
--- a/LMS.API/CustomActionFilter/ExceptionHandleMiddleware.cs
+++ b/LMS.API/CustomActionFilter/ExceptionHandleMiddleware.cs
@@ -1,0 +1,37 @@
+﻿using System.Text.Json;
+
+namespace LMS.API.CustomActionFilter;
+
+public class ExceptionHandleMiddleware
+{
+    private readonly ILogger<ExceptionHandleMiddleware> _logger;
+    private readonly RequestDelegate _next;
+
+    public ExceptionHandleMiddleware(ILogger<ExceptionHandleMiddleware> logger, RequestDelegate next)
+    {
+        this._logger = logger;
+        this._next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            //first thing to do is to log the exception
+            _logger.LogError(ex, ex.Message);
+            //second thing to do is to send a custom error response
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            context.Response.ContentType = "application/json";
+            var error = new
+            {
+                ErrorMessage = "An error occurred while processing your request.",
+                ExceptionMessage = ex.Message
+            };
+            await context.Response.WriteAsync(JsonSerializer.Serialize(error));
+        }
+    }
+}


### PR DESCRIPTION
Introduced a new middleware class `ExceptionHandleMiddleware` in the `LMS.API.CustomActionFilter` namespace to handle exceptions during HTTP request processing. The middleware uses dependency injection to obtain an `ILogger<ExceptionHandleMiddleware>` and a `RequestDelegate`. The `InvokeAsync` method wraps request processing in a try-catch block, logs exceptions, and sends a custom error response with a 500 status code and JSON body. Utilized `System.Text.Json` for JSON serialization.